### PR TITLE
make extra networks optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -45,13 +45,15 @@ variable "primary_network" {
 }
 
 variable "extra_networks" {
+  default     = null
   description = "Configuration of additional network interfaces."
-  type = list(object({
-    ips     = list(string)
-    macaddr = string
-    name    = string
-    netmask = number
-  }))
+  type        = any
+  #  type = list(object({
+  #  ips     = list(string)
+  #  macaddr = string
+  #  name    = string
+  # netmask = number
+  #})
 }
 
 variable "search_domains" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  # minimum required version for experimental features.
+  required_version = ">= 0.14.0"
+
+  # enable experimental optional variables.
+  # TODO: remove when no longer experimental.
+  experiments = [module_variable_optional_attrs]
+}


### PR DESCRIPTION
- allow experimental optional vars
- relax type constraint on extra networks
